### PR TITLE
Get database URL from environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           echo "POSTGRES_PORT=5434" >> $GITHUB_ENV
           echo "TESTING=true" >> $GITHUB_ENV
           echo "FAST_API_PORT=8001" >> $GITHUB_ENV
+          echo "SQLALCHEMY_DATABASE_URI=postgresql://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@localhost:5434/${{ secrets.POSTGRES_DB }}" >> $GITHUB_ENV
 
       # 3. Wait for test-db Service to Be Ready
       - name: Wait for test-db to be Ready

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     container_name: tckdb_app
     environment:
       - RUNNING_IN_DOCKER=true
+      - SQLALCHEMY_DATABASE_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVER}:5432/${POSTGRES_DB}
     env_file:
       - ./tckdb/backend/app/core/.env
     volumes:

--- a/tckdb/backend/alembic.ini
+++ b/tckdb/backend/alembic.ini
@@ -61,7 +61,10 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://test_user:test_pass@db:5432/test_db
+# The database URL is now provided via the SQLALCHEMY_DATABASE_URI
+# environment variable. Leave this option blank to avoid storing
+# credentials in the repository.
+sqlalchemy.url =
 
 
 [post_write_hooks]

--- a/tckdb/backend/alembic/env.py
+++ b/tckdb/backend/alembic/env.py
@@ -20,9 +20,15 @@ config = context.config
 # Interpret the config file for Python logging.
 fileConfig(config.config_file_name)
 
-# Set the SQLAlchemy URL from environment variables if not already set
-if not config.get_main_option("sqlalchemy.url"):
-    config.set_main_option("sqlalchemy.url", os.getenv("SQLALCHEMY_DATABASE_URI"))
+# Set the SQLAlchemy URL from an environment variable. This avoids
+# storing credentials in the alembic.ini file and makes the connection
+# configurable at runtime.
+database_url = os.getenv("SQLALCHEMY_DATABASE_URI")
+if not database_url:
+    raise EnvironmentError(
+        "The SQLALCHEMY_DATABASE_URI environment variable is not set."
+    )
+config.set_main_option("sqlalchemy.url", database_url)
 
 # Set target_metadata to your models' metadata
 target_metadata = Base.metadata


### PR DESCRIPTION
## Summary
- remove hardcoded `sqlalchemy.url` from Alembic config
- load DB URL from `SQLALCHEMY_DATABASE_URI` environment variable
- pass database URL via CI workflow and docker-compose

## Testing
- `python -m py_compile tckdb/backend/alembic/env.py`
- `pytest tckdb/backend/app/tests/schemas -q` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6894e16903f88322825a13d151a37f6f